### PR TITLE
Modify f2fs.h to integrate alfs extension

### DIFF
--- a/f2fs.h
+++ b/f2fs.h
@@ -910,6 +910,12 @@ struct f2fs_sb_info {
 	/* Reference to checksum algorithm driver via cryptoapi */
 	struct crypto_shash *s_chksum_driver;
 
+	/* For ALFS extension management */
+#ifdef ALFS_SNAPSHOT
+	struct alfs_info *ai;
+	spinlock_t mapping_lock;	/* lock for stat operations */
+#endif
+
 	/* For fault injection */
 #ifdef CONFIG_F2FS_FAULT_INJECTION
 	struct f2fs_fault_info fault_info;


### PR DESCRIPTION
* Now f2fs.h has the member variables of alfs extension.
* But it does not affect to f2fs yet, cause data.c, gc.c,
* segment.c and super.c are also needed integration.
This fixes #12