### PR TITLE
Integrate alfs extension into data.c

### DIFF
--- a/data.c
+++ b/data.c
@@ -29,6 +29,9 @@
 #include "trace.h"
 #include <trace/events/f2fs.h>
 
+#ifdef ALFS_SNAPSHOT
+#include "alfs_ext.h"
+#endif
 static bool __is_cp_guaranteed(struct page *page)
 {
 	struct address_space *mapping = page->mapping;
@@ -311,7 +314,11 @@ int f2fs_submit_page_bio(struct f2fs_io_info *fio)
 	}
 	bio_set_op_attrs(bio, fio->op, fio->op_flags);
 
+#ifdef ALFS_META_LOGGING
+	alfs_submit_merged_bio(fio->sbi, (bio_op(bio)), bio, 0);
+#else
 	__submit_bio(fio->sbi, bio, fio->type);
+#endif
 	return 0;
 }
 


### PR DESCRIPTION
## This should be reviewed by @chamdoo
* When it was 3.13, this feature modified `f2fs_readpage`.
* But now, `f2fs_readpage` had gone, and `f2fs_submit_page_bio` had replaced it. This means that the role had been changed and integrated with writing operation.
* Should I check the R/W operation and fire the code only if the operation is reading? Or, present code is OK?

* Check [@data.c](https://bitbucket.org/chamdoo/risa-f2fs/src)